### PR TITLE
[TASK]: Federal Entities Top 10 #2

### DIFF
--- a/apps/users/application/selectors/federal_entities_top10_queries.py
+++ b/apps/users/application/selectors/federal_entities_top10_queries.py
@@ -1,0 +1,11 @@
+from typing import List, Dict
+
+from apps.users.infrastructure.repositories.federal_entities_repo import get_top10_entidades
+
+
+def entidades_top10() -> List[Dict]:
+    """
+    Retorna a lo sumo 10 entidades, ordenadas desc por total.
+    """
+    data = get_top10_entidades()
+    return sorted(data, key=lambda d: d.get("total", 0), reverse=True)[:10]

--- a/apps/users/infrastructure/repositories/federal_entities_repo.py
+++ b/apps/users/infrastructure/repositories/federal_entities_repo.py
@@ -1,0 +1,18 @@
+from typing import List, Dict
+from django.db import connection
+
+def get_top10_entidades() -> List[Dict]:
+    """
+    Llama a la función Postgres f_cuenta_registros_por_entidad_top10()
+    y retorna una lista de dicts con keys:
+    ent_federativa_param, entidad_nombre, total
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            select ent_federativa_param, entidad_nombre, total
+            from f_cuenta_registros_por_entidad_top10()
+        """)
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+    return [dict(zip(cols, r)) for r in rows]
+

--- a/apps/users/infrastructure/web/serializer.py
+++ b/apps/users/infrastructure/web/serializer.py
@@ -34,3 +34,8 @@ class UsuarioResponseSerializer(serializers.Serializer):
     estatus = serializers.IntegerField()
     created_at = serializers.DateTimeField()
     updated_at = serializers.DateTimeField()
+
+class EntidadTopSerializer(serializers.Serializer):
+    ent_federativa_param = serializers.IntegerField()
+    entidad_nombre = serializers.CharField()
+    total = serializers.IntegerField()

--- a/apps/users/infrastructure/web/urls.py
+++ b/apps/users/infrastructure/web/urls.py
@@ -5,6 +5,8 @@ from .views import UsuarioViewSet
 router = DefaultRouter()
 router.register(r'users', UsuarioViewSet, basename='usuario')
 
+
 urlpatterns = [
     path('users/', include(router.urls)),
+    path('tableros/entidades/top10/', UsuarioViewSet.as_view({'get': 'entidades_top10_view'}), name='entidades-top10'),
 ]

--- a/apps/users/infrastructure/web/views.py
+++ b/apps/users/infrastructure/web/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 
+from apps.users.application.selectors.federal_entities_top10_queries import entidades_top10
 from apps.users.infrastructure.repositories.user_repo import PgUserRepository
 from apps.users.application.selectors.user_queries import UserQueriesSelector
 from apps.users.application.services.user_comands import UserCommandsService
@@ -10,6 +11,7 @@ from apps.users.infrastructure.web.serializer import (
     UsuarioCreateSerializer,
     UsuarioUpdateSerializer,
     UsuarioResponseSerializer,
+    EntidadTopSerializer
 )
 from rest_framework.permissions import AllowAny
 
@@ -117,4 +119,13 @@ class UsuarioViewSet(viewsets.ViewSet):
     def me(self, request):
         """Endpoint de ejemplo para representar el usuario autenticado."""
         return Response({"ok": True}, status=status.HTTP_200_OK)
- 
+
+    @extend_schema(
+        summary="Top 10 entidades federativas por número de registros",
+        responses={200: EntidadTopSerializer(many=True)},
+    )
+
+    @action(detail=False, methods=["get"])
+    def entidades_top10_view(self, request):
+        resultado = entidades_top10()
+        return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Resumen
Crear endpoint para mostrar las 10 entidades federativas con más registros.

## Tarea
- Implementar un endpoint REST en Django siguiendo Clean Architecture.
- Llamar a la función Postgres `f_cuenta_registros_por_entidad_top10()`.
- Endpoint: GET /api/tableros/entidades/top10/

<img width="1122" height="724" alt="Captura de pantalla 2025-10-02 a la(s) 11 08 12 a m" src="https://github.com/user-attachments/assets/3f7dd007-6e16-429c-b4d1-440a4945ab5c" />

