### PR TITLE
[TASK]: Registros por Estatus #7

### DIFF
--- a/apps/users/application/selectors/records_by_status.py
+++ b/apps/users/application/selectors/records_by_status.py
@@ -1,0 +1,6 @@
+from typing import List, Dict
+from apps.users.infrastructure.repositories.records_by_status_repo import StatusRecordsRepository
+
+def conteo_registros_por_estatus_selector() -> List[Dict]:
+    repo = StatusRecordsRepository()
+    return repo.obtener_conteo_por_estatus()

--- a/apps/users/infrastructure/repositories/records_by_status_repo.py
+++ b/apps/users/infrastructure/repositories/records_by_status_repo.py
@@ -1,0 +1,27 @@
+from typing import List, Dict
+from django.db import connection
+
+class StatusRecordsRepository:
+    def obtener_conteo_por_estatus(self) -> List[Dict[str, int]]:
+        """
+        Devuelve todos los estatus del catálogo con su total,
+        incluyendo los que tengan total = 0, ordenados por total desc.
+        """
+        query = """
+            WITH counts AS (
+                SELECT estatus_param, total
+                FROM f_cuenta_registros_por_status()
+            )
+            SELECT
+                p.nombre AS estatus,
+                COALESCE(c.total, 0) AS total
+            FROM parametrizacion AS p
+            LEFT JOIN counts c
+              ON c.estatus_param = p.id_param
+            ORDER BY total DESC, estatus ASC
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            cols = [c[0] for c in cursor.description]
+            rows = cursor.fetchall()
+        return [dict(zip(cols, r)) for r in rows]

--- a/apps/users/infrastructure/web/serializer.py
+++ b/apps/users/infrastructure/web/serializer.py
@@ -39,3 +39,7 @@ class EntidadTopSerializer(serializers.Serializer):
     ent_federativa_param = serializers.IntegerField()
     entidad_nombre = serializers.CharField()
     total = serializers.IntegerField()
+
+class StatusCountSerializer(serializers.Serializer):
+    estatus = serializers.CharField()
+    total = serializers.IntegerField()

--- a/apps/users/infrastructure/web/urls.py
+++ b/apps/users/infrastructure/web/urls.py
@@ -9,4 +9,5 @@ router.register(r'users', UsuarioViewSet, basename='usuario')
 urlpatterns = [
     path('users/', include(router.urls)),
     path('tableros/entidades/top10/', UsuarioViewSet.as_view({'get': 'entidades_top10_view'}), name='entidades-top10'),
+    path('tableros/registros/estatus/', UsuarioViewSet.as_view({'get': 'records_by_status_view'}), name='registros-por-estatus'),
 ]

--- a/apps/users/infrastructure/web/views.py
+++ b/apps/users/infrastructure/web/views.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 from apps.users.application.selectors.federal_entities_top10_queries import entidades_top10
+from apps.users.application.selectors.records_by_status import conteo_registros_por_estatus_selector
 from apps.users.infrastructure.repositories.user_repo import PgUserRepository
 from apps.users.application.selectors.user_queries import UserQueriesSelector
 from apps.users.application.services.user_comands import UserCommandsService
@@ -128,4 +129,13 @@ class UsuarioViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"])
     def entidades_top10_view(self, request):
         resultado = entidades_top10()
+        return Response(resultado, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Mostrar registros agrupados por estatus (Confirmada, Pendiente, Rechazada)",
+        responses={200: EntidadTopSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def records_by_status_view(self, request):
+        resultado = conteo_registros_por_estatus_selector()
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Resumen
Crear endpoint para mostrar registros agrupados por estatus (Confirmada, Pendiente, Rechazada, etc.).

## Tarea
- Implementar wrapper en Django siguiendo Clean Architecture.
- Llamar a la función Postgres `f_cuenta_registros_por_status()`.
- Hacer JOIN con la tabla `parametrizacion` para mapear nombres legibles.
- Crear selector, repositorio y vista.

<img width="1117" height="674" alt="Captura de pantalla 2025-10-02 a la(s) 1 33 16 p m" src="https://github.com/user-attachments/assets/ea0129c2-d0cf-43d1-930d-bf48d1011b0c" />
