### PR TITLE
FIX insertar y actualizar CEPAT

### DIFF
--- a/apps/cepat/application/services/cepat_commands.py
+++ b/apps/cepat/application/services/cepat_commands.py
@@ -28,7 +28,7 @@ class CepatCommandsService:
         # Solo Admin y Cepat pueden ejecutar comandos
         return rol_id == 35 or rol_id == 37
 
-    def create_cepat(self, user, nombre: str, id_usuario: int) -> Cepat:
+    def create_cepat(self, user, nombre: str, id_usuario: Optional[int] = None) -> Cepat:
         """
         Caso de uso para crear un nuevo Cepat.
         Lanza PermissionDenied si no es Admin (35) o Cepat (37).
@@ -38,7 +38,7 @@ class CepatCommandsService:
 
         return self.repo.create(nombre, id_usuario)
 
-    def update_cepat(self, user, cepat_id: int, nombre: str, id_usuario: int) -> Optional[Cepat]:
+    def update_cepat(self, user, cepat_id: int, nombre: str, id_usuario: Optional[int] = None) -> Optional[Cepat]:
         """
         Caso de uso para actualizar un Cepat.
         Lanza PermissionDenied si no es Admin (35) o Cepat (37).

--- a/apps/cepat/domain/entities.py
+++ b/apps/cepat/domain/entities.py
@@ -9,7 +9,7 @@ class Cepat:
     """
     id_cepat: int
     nombre: str
-    id_usuario: int
+    id_usuario: Optional[int]
 
 @dataclass
 class CepatPatchResult:

--- a/apps/cepat/domain/ports.py
+++ b/apps/cepat/domain/ports.py
@@ -8,7 +8,7 @@ class CepatRepositoryPort(Protocol):
     La lógica de negocio depende de esta interfaz, no de la implementación.
     """
 
-    def create(self, nombre: str, id_usuario: int) -> Cepat:
+    def create(self, nombre: str, id_usuario: Optional[int]) -> Cepat:
         """ Llama a f_inserta_cepat """
         ...
 
@@ -20,7 +20,7 @@ class CepatRepositoryPort(Protocol):
         """ Llama a f_busca_cepat_por_id """
         ...
 
-    def update(self, cepat_id: int, nombre: str, id_usuario: int) -> Optional[Cepat]:
+    def update(self, cepat_id: int, nombre: str, id_usuario: Optional[int]) -> Optional[Cepat]:
         """ Llama a f_actualiza_cepat_por_id """
         ...
 

--- a/apps/cepat/infrastructure/repositories/cepat_repo.py
+++ b/apps/cepat/infrastructure/repositories/cepat_repo.py
@@ -6,11 +6,11 @@ class CepatSerializer(serializers.Serializer):
     """
     id_cepat = serializers.IntegerField(read_only=True)
     nombre = serializers.CharField(read_only=True)
-    id_usuario = serializers.IntegerField(read_only=True)
+    id_usuario = serializers.IntegerField(read_only=True, allow_null=True)
 
 class CepatInputSerializer(serializers.Serializer):
     """
     Serializador para VALIDAR la entrada al crear o actualizar un Cepat. (Entrada)
     """
     nombre = serializers.CharField(max_length=255, required=True)
-    id_usuario = serializers.IntegerField(required=True)
+    id_usuario = serializers.IntegerField(required=True, allow_null=True)

--- a/apps/cepat/infrastructure/repositories/pg_utils.py
+++ b/apps/cepat/infrastructure/repositories/pg_utils.py
@@ -17,7 +17,7 @@ class PgCepatRepository(CepatRepositoryPort):
         """Mapea un diccionario de fila de BD a la entidad CepatPatchResult."""
         return CepatPatchResult(**row)
 
-    def create(self, nombre: str, id_usuario: int) -> Cepat:
+    def create(self, nombre: str, id_usuario: Optional[int]) -> Cepat:
         """ Llama a f_inserta_cepat """
 
         rows = call_fn_rows("public.f_inserta_cepat", [nombre, id_usuario])
@@ -34,7 +34,7 @@ class PgCepatRepository(CepatRepositoryPort):
         rows = call_fn_rows("public.f_busca_cepat_por_id", [cepat_id])
         return self._map_row_to_entity(rows[0]) if rows else None
 
-    def update(self, cepat_id: int, nombre: str, id_usuario: int) -> Optional[Cepat]:
+    def update(self, cepat_id: int, nombre: str, id_usuario: Optional[int]) -> Optional[Cepat]:
         """ Llama a f_actualiza_cepat_por_id """
 
         rows = call_fn_rows(

--- a/apps/cepat/infrastructure/web/serializer.py
+++ b/apps/cepat/infrastructure/web/serializer.py
@@ -15,7 +15,7 @@ class CepatInputSerializer(serializers.Serializer):
     Se usa para validar el 'request.data' de la vista.
     """
     nombre = serializers.CharField(max_length=255, required=True)
-    id_usuario = serializers.IntegerField(required=True)
+    id_usuario = serializers.IntegerField(required=True, allow_null=True)
 
 class CepatPatchUsuarioSerializer(serializers.Serializer):
     """


### PR DESCRIPTION
## Cambios realizados
Se modificaron los endpoints para insertar y actualizar CEPATs, de tal manera que ahora permiten que el campo id_usuario sea null.

## ¿Qué no se cambió?
Los demás endpoints sirven de la misma manera que antes

## Evidencias:
POST:
<img width="1710" height="1112" alt="Screenshot 2025-10-31 at 8 05 34 p m" src="https://github.com/user-attachments/assets/6ccea17a-e9ae-4ee9-a655-a948bacf9f8a" />


PUT:
<img width="1710" height="1112" alt="Screenshot 2025-10-31 at 8 13 05 p m" src="https://github.com/user-attachments/assets/8c1ab50a-e0ae-47e3-b860-65877043766b" />

