### PR TITLE
Feature/busca investigadores por coordinador

### DIFF
--- a/apps/consultas/application/selectors/investigador_por_coordinador.py
+++ b/apps/consultas/application/selectors/investigador_por_coordinador.py
@@ -1,0 +1,44 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.investigadores_por_coordinador_repo import (
+    get_investigadores_por_coordinador_repo
+)
+from apps.users.application.selectors.resolve_user_context import resolve_user_context
+
+# ID de rol para Coordinador (basado en tu ViewSet de ejemplo)
+ROL_COORDINADOR = 36
+
+
+def investigadores_por_coordinador_selector(user) -> List[Dict]:
+    """
+    Retorna la lista de investigadores asociados a la institución
+    del usuario coordinador autenticado.
+
+    Args:
+        user: Objeto de usuario autenticado de Django (request.user)
+
+    Comportamiento:
+    - Si el usuario NO es Coordinador (rol_id=36), retorna una lista vacía.
+    - Si ES Coordinador, llama al repositorio para buscar a sus investigadores.
+    """
+
+    # Obtener el ID del usuario de forma segura
+    id_usuario = getattr(user, "id", None) or getattr(user, "id_usuario", None)
+
+    if not id_usuario:
+        return []
+
+    # Resolver contexto del usuario para obtener su ROL
+    context = resolve_user_context(int(id_usuario))
+
+    if not context:
+        return []
+
+    rol_id = context.get("rol_id")
+
+    # Lógica de negocio: Solo los coordinadores pueden ver sus investigadores
+    if rol_id == ROL_COORDINADOR:
+        # Llamar al repositorio con el ID del coordinador
+        return get_investigadores_por_coordinador_repo(id_usuario=int(id_usuario))
+    else:
+        # Cualquier otro rol (Admin, CEPAT, etc.) no verá nada en este endpoint
+        return []

--- a/apps/consultas/application/selectors/usuarios_por_estados_cepat.py
+++ b/apps/consultas/application/selectors/usuarios_por_estados_cepat.py
@@ -1,0 +1,34 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.usuarios_por_estados_cepat_repo import (
+    get_usuarios_por_estados_cepat_repo
+)
+from apps.users.application.selectors.resolve_user_context import resolve_user_context
+
+ROL_CEPAT = 37
+
+
+def usuarios_por_estados_cepat_selector(user) -> List[Dict]:
+    """
+    Selector que obtiene los usuarios coordinadores ubicados en los mismos estados
+    que las instituciones del CEPAT autenticado.
+
+    Args:
+        user: Usuario autenticado (request.user).
+    """
+    # Obtener ID de usuario
+    id_usuario = getattr(user, "id", None) or getattr(user, "id_usuario", None)
+
+    if not id_usuario:
+        return []
+
+    # Resolver contexto
+    context = resolve_user_context(int(id_usuario))
+    if not context:
+        return []
+
+    rol_id = context.get("rol_id")
+
+    if rol_id == ROL_CEPAT:
+        return get_usuarios_por_estados_cepat_repo(id_usuario=int(id_usuario))
+
+    return []

--- a/apps/consultas/infrastructure/repositories/investigadores_por_coordinador_repo.py
+++ b/apps/consultas/infrastructure/repositories/investigadores_por_coordinador_repo.py
@@ -1,0 +1,30 @@
+from typing import List, Dict
+from django.db import connection
+
+
+def get_investigadores_por_coordinador_repo(id_usuario: int) -> List[Dict]:
+    """
+    Llama a la función Postgres f_busca_investigadores_por_coordinador(p_id_usuario)
+    y retorna los investigadores asociados a la(s) institución(es) de ese coordinador.
+
+    Args:
+        id_usuario: El id_usuario del coordinador.
+
+    Returns:
+        Lista de dicts con los datos de los investigadores.
+    """
+    with connection.cursor() as cursor:
+        query = """
+                SELECT * \
+                FROM public.f_busca_investigadores_por_coordinador(%s) \
+                """
+
+        # Pasa el id_usuario como parámetro a la función de Postgres
+        cursor.execute(query, [id_usuario])
+
+        # Obtiene los nombres de las columnas que retornó la función
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+
+    # Convierte los resultados en una lista de diccionarios
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/repositories/usuarios_por_estados_cepat_repo.py
+++ b/apps/consultas/infrastructure/repositories/usuarios_por_estados_cepat_repo.py
@@ -1,0 +1,26 @@
+from typing import List, Dict
+from django.db import connection
+
+
+def get_usuarios_por_estados_cepat_repo(id_usuario: int) -> List[Dict]:
+    """
+    Llama a la función Postgres f_buscar_usuarios_por_estados_de_cepat(p_id_usuario)
+
+    Args:
+        id_usuario: ID del usuario CEPAT.
+
+    Returns:
+        Lista de diccionarios con la información de los usuarios (coordinadores)
+        que se encuentran en los estados gestionados por este CEPAT.
+    """
+    with connection.cursor() as cursor:
+        query = """
+                SELECT * \
+                FROM public.f_buscar_usuarios_por_estados_de_cepat(%s) \
+                """
+        cursor.execute(query, [id_usuario])
+
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -60,3 +60,14 @@ class InvestigadorPorCoordinadorSerializer(serializers.Serializer):
     ape_mat = serializers.CharField(required=False, allow_null=True)
     sexo_param = serializers.IntegerField()
     tipo_investigador_param = serializers.IntegerField()
+
+class UsuarioPorEstadoCepatSerializer(serializers.Serializer):
+    id_usuario = serializers.IntegerField()
+    nombre = serializers.CharField()
+    ape_pat = serializers.CharField()
+    ape_mat = serializers.CharField(required=False, allow_null=True)
+    url_foto = serializers.CharField(required=False, allow_null=True)
+    correo = serializers.EmailField()
+    telefono = serializers.CharField()
+    tipo_usuario_param = serializers.IntegerField()
+    estatus_param = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -51,3 +51,12 @@ class InstitucionAllSerializer(serializers.Serializer):
     institucion_nombre = serializers.CharField()
     tipo_institucion = serializers.CharField()
     total = serializers.IntegerField()
+
+class InvestigadorPorCoordinadorSerializer(serializers.Serializer):
+    id_investigador = serializers.IntegerField()
+    curp = serializers.CharField()
+    nombre = serializers.CharField()
+    ape_pat = serializers.CharField()
+    ape_mat = serializers.CharField(required=False, allow_null=True)
+    sexo_param = serializers.IntegerField()
+    tipo_investigador_param = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path('sectores/actividad/all/', ConsultaViewSet.as_view({'get': 'sectores_actividad_all_view'}), name='sectores-actividad-all'),
     path('instituciones/filtradas/', ConsultaViewSet.as_view({'get': 'instituciones_filtradas_view'}), name='instituciones-filtradas'),
     path('investigadores/por-coordinador/', ConsultaViewSet.as_view({'get': 'investigadores_por_coordinador_view'}), name='investigadores-por-coordinador'),
+    path('usuarios/por-estados-cepat/', ConsultaViewSet.as_view({'get': 'usuarios_por_estados_cepat_view'}), name='usuarios-por-estados-cepat'),
 ]

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('registros/periodo/', ConsultaViewSet.as_view({'get': 'registros_por_periodo'}), name='registros-por-periodo'),
     path('sectores/actividad/all/', ConsultaViewSet.as_view({'get': 'sectores_actividad_all_view'}), name='sectores-actividad-all'),
     path('instituciones/filtradas/', ConsultaViewSet.as_view({'get': 'instituciones_filtradas_view'}), name='instituciones-filtradas'),
+    path('investigadores/por-coordinador/', ConsultaViewSet.as_view({'get': 'investigadores_por_coordinador_view'}), name='investigadores-por-coordinador'),
 ]

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -17,9 +17,8 @@ from apps.consultas.application.selectors.records_by_month_queries import regist
 from apps.consultas.application.selectors.sectors_activity_all_selector import sectores_actividad_all
 from apps.consultas.application.selectors.records_by_period import registros_por_periodo_selector
 from apps.consultas.application.selectors.institutions_filtered_queries import instituciones_filtradas_selector
-from apps.consultas.application.selectors.investigador_por_coordinador import (
-    investigadores_por_coordinador_selector
-)
+from apps.consultas.application.selectors.investigador_por_coordinador import investigadores_por_coordinador_selector
+from apps.consultas.application.selectors.usuarios_por_estados_cepat import usuarios_por_estados_cepat_selector
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     StatusCountSerializer,
@@ -31,8 +30,8 @@ from apps.consultas.infrastructure.web.serializer import (
     SectorActividadSerializer,
     RegistrosPorMesSerializer,
     RegistrosPorPeriodoSerializer, InstitucionAllSerializer,
-    InvestigadorPorCoordinadorSerializer
-
+    InvestigadorPorCoordinadorSerializer,
+    UsuarioPorEstadoCepatSerializer
 )
 
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -293,4 +292,14 @@ class ConsultaViewSet(viewsets.ViewSet):
         """
         # Llama al selector pasándole el usuario autenticado
         resultado = investigadores_por_coordinador_selector(request.user)
+        return Response(resultado, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="[CEPAT] Obtener usuarios coordinadores en los estados del CEPAT",
+        description="Devuelve la info completa de usuarios cuyas instituciones están en los mismos estados que gestiona el CEPAT logueado.",
+        responses={200: UsuarioPorEstadoCepatSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def usuarios_por_estados_cepat_view(self, request):
+        resultado = usuarios_por_estados_cepat_selector(request.user)
         return Response(resultado, status=status.HTTP_200_OK)

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -17,6 +17,9 @@ from apps.consultas.application.selectors.records_by_month_queries import regist
 from apps.consultas.application.selectors.sectors_activity_all_selector import sectores_actividad_all
 from apps.consultas.application.selectors.records_by_period import registros_por_periodo_selector
 from apps.consultas.application.selectors.institutions_filtered_queries import instituciones_filtradas_selector
+from apps.consultas.application.selectors.investigador_por_coordinador import (
+    investigadores_por_coordinador_selector
+)
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     StatusCountSerializer,
@@ -27,7 +30,8 @@ from apps.consultas.infrastructure.web.serializer import (
     RequestTypeSerializer,
     SectorActividadSerializer,
     RegistrosPorMesSerializer,
-    RegistrosPorPeriodoSerializer, InstitucionAllSerializer
+    RegistrosPorPeriodoSerializer, InstitucionAllSerializer,
+    InvestigadorPorCoordinadorSerializer
 
 )
 
@@ -275,4 +279,18 @@ class ConsultaViewSet(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST
             )
         resultado = instituciones_filtradas_selector(tipo_institucion)
+        return Response(resultado, status=status.HTTP_200_OK)
+
+    @extend_schema(
+            summary="[Coordinador] Lista los investigadores de la institución del coordinador",
+            responses={200: InvestigadorPorCoordinadorSerializer(many=True)},
+        )
+    @action(detail=False, methods=["get"])
+    def investigadores_por_coordinador_view(self, request):
+        """
+        Endpoint que retorna los investigadores asociados a la(s) institución(es)
+        del usuario coordinador que realiza la petición.
+        """
+        # Llama al selector pasándole el usuario autenticado
+        resultado = investigadores_por_coordinador_selector(request.user)
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
# ¿Que se realizó?
Se implementaron los endpoints para obtener la lista de usuarios pertenecientes a los estados del usuario cepat en sesión y la lista de insvestigadores por coordinador.

## Endpoints
http://127.0.0.1:8000/api/tableros/investigadores/por-coordinador/
(Usuario: coor@test.com Pass:MiPasswordCoor)
http://127.0.0.1:8000/api/tableros/usuarios/por-estados-cepat/
(Usuario: john_d@gmail.com Pass: Contraseña1)

# Evidencias
Investigadores por coordinador:
<img width="1710" height="1112" alt="Screenshot 2025-11-17 at 12 53 05 p m" src="https://github.com/user-attachments/assets/1f33c59f-3751-447a-afc0-aa73e34ab4e9" />

Usuarios por estados de CEPAT:
<img width="1710" height="1112" alt="Screenshot 2025-11-17 at 3 39 23 p m" src="https://github.com/user-attachments/assets/efd855ce-4104-43cb-b68f-70ef180b724a" />
