### PR TITLE
Registros de programas por institucion de coord

### DIFF
--- a/apps/consultas/application/selectors/registros_por_programa_selector.py
+++ b/apps/consultas/application/selectors/registros_por_programa_selector.py
@@ -1,0 +1,29 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.registros_por_programa_repo import (
+    get_registros_por_programa_repo
+)
+from apps.users.application.selectors.resolve_user_context import resolve_user_context
+
+ROL_COORDINADOR = 36
+
+
+def registros_por_programa_selector(user) -> List[Dict]:
+    """
+    Lógica de negocio: Valida que el usuario sea coordinador y obtiene
+    el conteo de registros por programa educativo.
+    """
+    id_usuario = getattr(user, "id", None) or getattr(user, "id_usuario", None)
+
+    if not id_usuario:
+        return []
+
+    context = resolve_user_context(int(id_usuario))
+    if not context:
+        return []
+
+    rol_id = context.get("rol_id")
+
+    if rol_id == ROL_COORDINADOR:
+        return get_registros_por_programa_repo(id_usuario=int(id_usuario))
+
+    return []

--- a/apps/consultas/infrastructure/repositories/registros_por_programa_repo.py
+++ b/apps/consultas/infrastructure/repositories/registros_por_programa_repo.py
@@ -1,0 +1,15 @@
+from typing import List, Dict
+from django.db import connection
+
+
+def get_registros_por_programa_repo(id_usuario: int) -> List[Dict]:
+    """
+    Ejecuta la función f_conteo_registros_por_programa_coordinador.
+    """
+    with connection.cursor() as cursor:
+        query = "SELECT * FROM public.f_conteo_registros_por_programa_coordinador(%s)"
+        cursor.execute(query, [id_usuario])
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -74,3 +74,7 @@ class ProgramaEducativoSerializer(serializers.Serializer):
     programa_educativo_param = serializers.IntegerField()
     nombre_programa_educativo = serializers.CharField(max_length=255)
     total = serializers.IntegerField()
+
+class RegistrosPorProgramaSerializer(serializers.Serializer):
+    programa_educativo = serializers.CharField()
+    total_registros = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -25,5 +25,5 @@ urlpatterns = [
     path('investigadores/por-coordinador/', ConsultaViewSet.as_view({'get': 'investigadores_por_coordinador_view'}), name='investigadores-por-coordinador'),
     path('usuarios/por-estados-cepat/', ConsultaViewSet.as_view({'get': 'usuarios_por_estados_cepat_view'}), name='usuarios-por-estados-cepat'),
     path('programas-educativos/', ConsultaViewSet.as_view({'get': 'programas_educativos_view'}), name='programas-educativos'),
-
+    path('registros/por-programa/', ConsultaViewSet.as_view({'get': 'registros_por_programa_view'}), name='registros-por-programa'),
 ]

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -20,6 +20,7 @@ from apps.consultas.application.selectors.institutions_filtered_queries import i
 from apps.consultas.application.selectors.investigador_por_coordinador import investigadores_por_coordinador_selector
 from apps.consultas.application.selectors.usuarios_por_estados_cepat import usuarios_por_estados_cepat_selector
 from apps.consultas.application.selectors.programs_educational_queries import registros_por_programa_educativo_selector
+from apps.consultas.application.selectors.registros_por_programa_selector import registros_por_programa_selector
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     CategoriaInvestigadorSerializer,
@@ -34,6 +35,7 @@ from apps.consultas.infrastructure.web.serializer import (
     InvestigadorPorCoordinadorSerializer,
     UsuarioPorEstadoCepatSerializer,
     ProgramaEducativoSerializer,
+    RegistrosPorProgramaSerializer,
 )
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from apps.users.application.services.permissions import HasRole
@@ -312,4 +314,14 @@ class ConsultaViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"])
     def programas_educativos_view(self, request):
         resultado = registros_por_programa_educativo_selector(request.user)
+        return Response(resultado, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="[Coordinador] Conteo de registros por Programa Educativo",
+        description="Devuelve la cantidad de registros agrupados por el programa educativo de la institución del coordinador.",
+        responses={200: RegistrosPorProgramaSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def registros_por_programa_view(self, request):
+        resultado = registros_por_programa_selector(request.user)
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
# ¿Qué se hizo?
Se creó el endpoint y la función almacenada para obtener el total de registros por cada programa de la institución del coordinador. Obtiene la información a partir del token del usuario coordinador el cual está en sesión.

## Endpoint:
GET http://127.0.0.1:8000/api/tableros/registros/por-programa/

# Evidencia:
<img width="1710" height="1112" alt="Screenshot 2025-11-19 at 10 07 53 p m" src="https://github.com/user-attachments/assets/745e54a0-5de6-4c6e-bc57-e036c2637b7d" />
(por el momento y debido a los datos que existen en la bd, funciona con el usuario:jona@coor.com pass:1234567890C y el usuario:coor@test.com pass:MiPasswordCoor)