### PR TITLE
Fix coordnadores por institucion cepat

### DIFF
--- a/apps/consultas/application/selectors/coordinadores_por_cepat_selector.py
+++ b/apps/consultas/application/selectors/coordinadores_por_cepat_selector.py
@@ -1,0 +1,22 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.coordinadores_por_cepat_repo import (
+    get_coordinadores_por_usuario_cepat_repo
+)
+from apps.users.application.selectors.resolve_user_context import resolve_user_context
+
+ROL_CEPAT_CONSULTA = 37
+
+def coordinadores_por_cepat_selector(user) -> List[Dict]:
+    """
+    Obtiene los coordinadores asociados a las instituciones del CEPAT en sesión.
+    """
+    id_usuario = getattr(user, "id", None) or getattr(user, "id_usuario", None)
+
+    if not id_usuario:
+        return []
+
+    context = resolve_user_context(int(id_usuario))
+    if not context or context.get("rol_id") != ROL_CEPAT_CONSULTA:
+        return []
+
+    return get_coordinadores_por_usuario_cepat_repo(id_usuario_sesion=int(id_usuario))

--- a/apps/consultas/infrastructure/repositories/coordinadores_por_cepat_repo.py
+++ b/apps/consultas/infrastructure/repositories/coordinadores_por_cepat_repo.py
@@ -1,0 +1,15 @@
+from typing import List, Dict
+from django.db import connection
+
+
+def get_coordinadores_por_usuario_cepat_repo(id_usuario_sesion: int) -> List[Dict]:
+    """
+    Ejecuta la función f_obtener_coordinadores_por_usuario_cepat.
+    """
+    with connection.cursor() as cursor:
+        query = "SELECT * FROM public.f_obtener_coordinadores_por_usuario_cepat(%s)"
+        cursor.execute(query, [id_usuario_sesion])
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -78,3 +78,17 @@ class ProgramaEducativoSerializer(serializers.Serializer):
 class RegistrosPorProgramaSerializer(serializers.Serializer):
     programa_educativo = serializers.CharField()
     total_registros = serializers.IntegerField()
+
+
+class CoordinadorConInstitucionSerializer(serializers.Serializer):
+    id_usuario = serializers.IntegerField()
+    nombre = serializers.CharField()
+    ape_pat = serializers.CharField()
+    ape_mat = serializers.CharField(required=False, allow_null=True)
+    url_foto = serializers.CharField(required=False, allow_null=True)
+    correo = serializers.EmailField()
+    telefono = serializers.CharField()
+    tipo_usuario_param = serializers.IntegerField()
+    estatus_param = serializers.IntegerField()
+    id_institucion = serializers.IntegerField()
+    nombre_institucion = serializers.CharField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     path('usuarios/por-estados-cepat/', ConsultaViewSet.as_view({'get': 'usuarios_por_estados_cepat_view'}), name='usuarios-por-estados-cepat'),
     path('programas-educativos/', ConsultaViewSet.as_view({'get': 'programas_educativos_view'}), name='programas-educativos'),
     path('registros/por-programa/', ConsultaViewSet.as_view({'get': 'registros_por_programa_view'}), name='registros-por-programa'),
+    path('coordinadores/por-cepat/', ConsultaViewSet.as_view({'get': 'coordinadores_por_cepat_view'}), name='coordinadores-por-cepat'),
 ]

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -21,6 +21,7 @@ from apps.consultas.application.selectors.investigador_por_coordinador import in
 from apps.consultas.application.selectors.usuarios_por_estados_cepat import usuarios_por_estados_cepat_selector
 from apps.consultas.application.selectors.programs_educational_queries import registros_por_programa_educativo_selector
 from apps.consultas.application.selectors.registros_por_programa_selector import registros_por_programa_selector
+from apps.consultas.application.selectors.coordinadores_por_cepat_selector import coordinadores_por_cepat_selector
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     CategoriaInvestigadorSerializer,
@@ -36,6 +37,7 @@ from apps.consultas.infrastructure.web.serializer import (
     UsuarioPorEstadoCepatSerializer,
     ProgramaEducativoSerializer,
     RegistrosPorProgramaSerializer,
+    CoordinadorConInstitucionSerializer
 )
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from apps.users.application.services.permissions import HasRole
@@ -324,4 +326,14 @@ class ConsultaViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"])
     def registros_por_programa_view(self, request):
         resultado = registros_por_programa_selector(request.user)
+        return Response(resultado, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="[CEPAT] Obtener coordinadores asociados",
+        description="Obtiene lista de coordinadores (usuarios) que pertenecen a las instituciones del CEPAT en sesión.",
+        responses={200: CoordinadorConInstitucionSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def coordinadores_por_cepat_view(self, request):
+        resultado = coordinadores_por_cepat_selector(request.user)
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
# ¿Qué se hizo?
Se creó un nuevo endpoint para obtener todos los coordinadores de un CEPAT por su institución.

### Endpoint:
http://127.0.0.1:8000/api/tableros/coordinadores/por-cepat/
### Para probar 
Debido a los datos que existen actualmente en la base de datos, el usuario cepat con el que se hizo la prueba es:
{
    "correo": "john_d@gmail.com",
    "password": "Contraseña1"
}


# Evidencias:
<img width="1710" height="1112" alt="Screenshot 2025-11-20 at 4 10 25 p m" src="https://github.com/user-attachments/assets/22596972-1d40-4685-8d2d-316d8d61a330" />
